### PR TITLE
Prevent Deploy Action from running on PRs (fixes #29)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: Build and deploy
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
The Deploy Action shouldn't run on a PR, as it will cause errors. This PR fixes that.
Fixes #29 